### PR TITLE
Remove unused import

### DIFF
--- a/src/chimed/config.py
+++ b/src/chimed/config.py
@@ -11,7 +11,6 @@ import collections.abc
 import toml
 import json
 import yaml
-from distutils.util import strtobool
 from xdg.BaseDirectory import xdg_config_home
 try:
     import configparser


### PR DESCRIPTION
This adds dependency to `distutils` which I couldn't figure out how to install to be available within `pipx`, but it turns out `strtobool` isn't used anywhere so at least it solves the issue for me.

EDIT: oh, but this now breaks the versioning? :thinking: 