### PR TITLE
Fix stale lock, replace rate-limit with debounce, add example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,15 @@ The internal configuration can be viewed using:
     chimed config get
 
 You can put YAML, TOML and JSON files in the `~/.config/chimed/conf.d/`
-directory to add or modify configuration options. Currently there's not much
-configuration to be done, a lot of things need to be implemented, so stay
-tuned.
+directory to add or modify configuration options. See
+[`lib/example-config.toml`](lib/example-config.toml) for a starting point.
+
+### Bell options
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `resource` | — | WAV file from the bundled package (see `chimed config get bells`) |
+| `min_interval` | `0.08` | Minimum seconds between successive plays of this bell — controls the rate limit (lower = more responsive, higher = gentler on resources) |
 
 ## Copyright
 

--- a/lib/example-config.toml
+++ b/lib/example-config.toml
@@ -1,0 +1,35 @@
+# Copyright (C) 2026 Maciej Delmanowski <drybjed@gmail.com>
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Example chimed configuration — place in ~/.config/chimed/conf.d/
+# to override defaults.  TOML, YAML, and JSON are all supported.
+
+
+# === Bell definitions ===
+#
+# Each bell has a name and a resource (WAV file from the bundled package).
+# You can also add custom bells using the 'filename' key (not shown here).
+# Configuration files in conf.d/ are merged with the defaults; you only
+# need to specify the values you want to override.
+
+[bells.chime2]
+resource = "ueffects-l-key.wav"
+min_interval = 0.04
+
+[bells.custom-bell]
+resource = "richcraft-chime-4.wav"
+min_interval = 0.1
+
+
+# === Input-to-bell mappings ===
+#
+# Each input matches a string written to the FIFO and maps it to a bell.
+# Multiple inputs can map to the same bell.
+
+[[inputs]]
+string = "CustomEvent"
+output = "custom-bell"
+
+[[inputs]]
+string = "BufWritePre"
+output = "chime4"

--- a/src/chimed/bell.py
+++ b/src/chimed/bell.py
@@ -8,6 +8,7 @@ import pkgutil
 import numpy
 import os
 import io
+import time
 
 
 class Bell(object):
@@ -17,6 +18,8 @@ class Bell(object):
         self.name = name
         self.args = args
         self.kwargs = kwargs
+        self._last_play_time = 0
+        self._min_interval = self.kwargs.get('min_interval', 0.08)
 
         if resource:
             self.type = 'resource'
@@ -57,9 +60,10 @@ class Bell(object):
                 raise Exception
 
     def play(self):
-        # Skip if previous playback for this bell is still active
-        if hasattr(self, '_play_obj') and self._play_obj and self._play_obj.is_playing():
+        now = time.monotonic()
+        if now - self._last_play_time < self._min_interval:
             return
+        self._last_play_time = now
         if self.type == 'resource':
             try:
                 self._play_obj = simpleaudio.play_buffer(self._audio_data, num_channels=1,

--- a/src/chimed/daemon.py
+++ b/src/chimed/daemon.py
@@ -3,6 +3,7 @@
 
 from .bell import Bell
 import atexit
+import errno
 import shutil
 import sys
 import xdg
@@ -16,12 +17,27 @@ class Daemon(object):
         self._args = args
         self._config = config
         self._fifo_bell = os.path.join(xdg.BaseDirectory.get_runtime_dir(), 'chimed', 'fifo')
+        self._fifo_dir = os.path.dirname(self._fifo_bell)
 
         try:
-            os.mkdir(os.path.dirname(self._fifo_bell))
+            os.mkdir(self._fifo_dir)
         except FileExistsError:
-            print('Another copy of chimed is running already. Exiting.')
-            sys.exit(1)
+            if os.path.exists(self._fifo_bell):
+                try:
+                    fd = os.open(self._fifo_bell, os.O_WRONLY | os.O_NONBLOCK)
+                    os.close(fd)
+                except OSError as exc:
+                    if exc.errno == errno.ENXIO:
+                        shutil.rmtree(self._fifo_dir)
+                        os.mkdir(self._fifo_dir)
+                    else:
+                        raise
+                else:
+                    print('Another copy of chimed is running already. Exiting.')
+                    sys.exit(1)
+            else:
+                shutil.rmtree(self._fifo_dir)
+                os.mkdir(self._fifo_dir)
 
         os.mkfifo(self._fifo_bell)
 
@@ -44,4 +60,4 @@ class Daemon(object):
                 sys.exit()
 
     def cleanup(self):
-        shutil.rmtree(os.path.dirname(self._fifo_bell))
+        shutil.rmtree(self._fifo_dir)


### PR DESCRIPTION
When the daemon is killed by OOM killer, atexit cleanup never runs and the lock directory survives, preventing restart.  Instead of bailing immediately on FileExistsError, check whether the FIFO has a live reader — if not, clean up the stale lock and proceed.

The previous rate limit blocked playback for the full duration of a chime (200ms+), making vim scrolling feel sluggish since every CursorMoved event during a chime was dropped.  Replaced with a time-based debounce (default 80ms, configurable per-bell via min_interval) that allows distinct chimes at a natural scrolling pace while still capping the maximum rate.

Includes an example configuration file at lib/example-config.toml with documented bell options in the README.